### PR TITLE
Syncoriginal

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -35,7 +35,11 @@ func (c *Cache) ServeDNS(ctx context.Context, w MessageWriter, r *Query) {
 	}
 
 	msg, err := w.Recur(ctx)
-	if err == nil && msg.RCode == NoError {
+	if err != nil || msg == nil {
+		w.Status(ServFail)
+		return
+	}
+	if msg.RCode == NoError {
 		c.insert(msg, now)
 	}
 	writeMessage(w, msg)

--- a/client.go
+++ b/client.go
@@ -34,8 +34,8 @@ func (c *Client) Dial(ctx context.Context, network, address string) (net.Conn, e
 			return nil, err
 		}
 
-		return streamSession{
-			session: &session{
+		return &streamSession{
+			session: session{
 				Conn:    conn,
 				addr:    addr,
 				client:  c,
@@ -43,7 +43,6 @@ func (c *Client) Dial(ctx context.Context, network, address string) (net.Conn, e
 			},
 		}, nil
 	case "udp", "udp4", "udp6":
-
 		addr, err := net.ResolveUDPAddr(network, address)
 		if err != nil {
 			return nil, err
@@ -54,8 +53,8 @@ func (c *Client) Dial(ctx context.Context, network, address string) (net.Conn, e
 			return nil, err
 		}
 
-		return packetSession{
-			session: &session{
+		return &packetSession{
+			session: session{
 				Conn:    conn,
 				addr:    addr,
 				client:  c,

--- a/client_test.go
+++ b/client_test.go
@@ -32,10 +32,14 @@ func TestLookupHost(t *testing.T) {
 
 	srv := mustServer(&Zone{
 		Origin: "dev.",
-		RRs: map[string][]Record{
+		RRs: RRSet{
 			"localhost": {
-				&A{A: net.IPv4(127, 0, 0, 1)},
-				&AAAA{AAAA: net.ParseIP("::1")},
+				TypeA: {
+					&A{A: net.IPv4(127, 0, 0, 1)},
+				},
+				TypeAAAA: {
+					&AAAA{AAAA: net.ParseIP("::1")},
+				},
 			},
 		},
 	})

--- a/compression_test.go
+++ b/compression_test.go
@@ -46,6 +46,13 @@ func TestCompressor(t *testing.T) {
 				0xC0, 0x05,
 			},
 		},
+		{
+			name: "invalid-fqdn",
+
+			fqdn: "invalid.com",
+
+			err: errInvalidFQDN,
+		},
 	}
 
 	t.Parallel()
@@ -58,8 +65,15 @@ func TestCompressor(t *testing.T) {
 
 			com := compressor{test.state, 0}
 
-			if want, got := len(test.raw), com.Length(test.fqdn); want != got {
-				t.Fatalf("want compressed length %d, got %d", want, got)
+			length, err := com.Length(test.fqdn)
+			if err != nil {
+				if want, got := test.err, err; want != got {
+					t.Errorf("want err %q, got %q", want, got)
+				}
+			} else {
+				if want, got := len(test.raw), length; want != got {
+					t.Fatalf("want compressed length %d, got %d", want, got)
+				}
 			}
 
 			raw, err := com.Pack(test.buf, test.fqdn)

--- a/doc.go
+++ b/doc.go
@@ -43,7 +43,7 @@ A handler answers queries for a server or a local resolver for a client:
 	zone := &dns.Zone{
 		Origin: "localhost.",
 		TTL:    5 * time.Minute,
-		RRs: map[string][]dns.Record{
+		RRs: dns.RRSet{
 			"alpha": []dns.Record{
 				&dns.A{net.IPv4(127, 0, 0, 42).To4()},
 				&dns.AAAA{net.ParseIP("::42")},

--- a/edns/edns.go
+++ b/edns/edns.go
@@ -1,0 +1,84 @@
+// Package edns provides EDNS0 (RFC6891) support.
+package edns
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+var nbo = binary.BigEndian
+
+// An OptionCode is a EDNS0 option code.
+type OptionCode uint16
+
+// DNS EDNS0 Option Codes (OPT).
+//
+// Taken from https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11
+const (
+	// 0	Reserved		[RFC6891]
+	OptionCodeLLQ  OptionCode = 1 // On-hold  [RFC6891]
+	OptionCodeUL   OptionCode = 2 // On-hold  [http://files.dns-sd.org/draft-sekar-dns-llq.txt]
+	OptionCodeNSID OptionCode = 3 // Standard [http://files.dns-sd.org/draft-sekar-dns-ul.txt]
+	// 4	Reserved		[draft-cheshire-edns0-owner-option]
+	OptionCodeDAU              OptionCode = 5  // Standard [RFC6975]
+	OptionCodeDHU              OptionCode = 6  // Standard [RFC6975]
+	OptionCodeN3U              OptionCode = 7  // Standard [RFC6975]
+	OptionCodeEDNSClientSubnet OptionCode = 8  // Optional [RFC7871]
+	OptionCodeEDNSExpire       OptionCode = 9  // Optional [RFC7314]
+	OptionCodeCookie           OptionCode = 10 // Standard [RFC7873]
+	OptionCodeEDNSTCPKeepAlive OptionCode = 11 // Standard [RFC7828]
+	OptionCodePadding          OptionCode = 12 // Standard [RFC7830]
+	OptionCodeChain            OptionCode = 13 // Standard [RFC7901]
+	OptionCodeEDNSKeyTag       OptionCode = 14 // Optional [RFC8145]
+	// 15-26945	Unassigned
+	OptionCodeDeviceID OptionCode = 26946 // Optional [https://docs.umbrella.com/developer/networkdevices-api/identifying-dns-traffic2][Brian_Hartvigsen]
+	// 26947-65000	Unassigned
+	// 65001-65534	Reserved for Local/Experimental Use	[RFC6891]
+	// 65535	Reserved for future expansion		[RFC6891]
+)
+
+var errOptionLen = errors.New("insufficient data for option length")
+
+// Option is a EDNS0 option.
+type Option struct {
+	Code OptionCode
+	Data []byte
+}
+
+// Length returns the encoded RDATA size.
+func (o Option) Length() int { return 4 + len(o.Data) }
+
+// Pack encodes o as RDATA.
+func (o Option) Pack(b []byte) ([]byte, error) {
+	var (
+		code   = uint16(o.Code)
+		length = uint16(len(o.Data))
+	)
+
+	buf := make([]byte, o.Length())
+	nbo.PutUint16(buf[:2], code)
+	nbo.PutUint16(buf[2:4], length)
+	copy(buf[4:], o.Data)
+
+	return append(b, buf[:]...), nil
+}
+
+// Unpack decodes o from RDATA in b.
+func (o *Option) Unpack(b []byte) ([]byte, error) {
+	if len(b) < 4 {
+		return nil, errOptionLen
+	}
+
+	o.Code = OptionCode(nbo.Uint16(b[:2]))
+	l := int(nbo.Uint16(b[2:4]))
+
+	if len(b) < 4+l {
+		return nil, io.ErrShortBuffer
+	}
+
+	o.Data = make([]byte, l)
+	copy(o.Data, b[4:])
+
+	return b[4+l:], nil
+}

--- a/edns/edns_test.go
+++ b/edns/edns_test.go
@@ -1,0 +1,87 @@
+package edns
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestOptionPackUnpack(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+
+		opt Option
+
+		raw []byte
+	}{
+		{
+			name: "COOKIE: client cookie to unknown server",
+
+			opt: Option{
+				Code: OptionCodeCookie,
+				Data: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
+			},
+
+			raw: []byte{
+				0x00, 0x0A, // OPTION-CODE = 10
+				0x00, 0x08, // OPTION-LENGTH = 8
+				0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // Client Cookie (fixed size, 8 bytes)
+			},
+		},
+		{
+			name: "COOKIE: client cookie to known server",
+
+			opt: Option{
+				Code: OptionCodeCookie,
+				Data: []byte{
+					0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+
+					0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+					0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+				},
+			},
+
+			raw: []byte{
+				0x00, 0x0A, // OPTION-CODE = 10
+				0x00, 0x18, // OPTION-LENGTH = 24
+
+				0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // Client Cookie (fixed size, 8 bytes)
+
+				0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, // Server Cookie  (variable size, 8 to 32 bytes)
+				0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := test.opt.Pack(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if want, got := test.raw, raw; !bytes.Equal(want, got) {
+				t.Errorf("want raw option %+v, got %+v", want, got)
+			}
+
+			opt := new(Option)
+			buf, err := opt.Unpack(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(buf) > 0 {
+				t.Errorf("left-over data after unpack: %x", buf)
+			}
+
+			if want, got := test.opt, *opt; !reflect.DeepEqual(want, got) {
+				t.Errorf("want option %+v, got %+v", want, got)
+			}
+		})
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -70,26 +70,42 @@ func ExampleServer_authoritative() {
 			MBox:   "hostmaster.tld.",
 			Serial: 1234,
 		},
-		RRs: map[string][]dns.Record{
+		RRs: dns.RRSet{
 			"1.app": {
-				&dns.A{A: net.IPv4(10, 42, 0, 1).To4()},
-				&dns.AAAA{AAAA: net.ParseIP("dead:beef::1")},
+				dns.TypeA: {
+					&dns.A{A: net.IPv4(10, 42, 0, 1).To4()},
+				},
+				dns.TypeAAAA: {
+					&dns.AAAA{AAAA: net.ParseIP("dead:beef::1")},
+				},
 			},
 			"2.app": {
-				&dns.A{A: net.IPv4(10, 42, 0, 2).To4()},
-				&dns.AAAA{AAAA: net.ParseIP("dead:beef::2")},
+				dns.TypeA: {
+					&dns.A{A: net.IPv4(10, 42, 0, 2).To4()},
+				},
+				dns.TypeAAAA: {
+					&dns.AAAA{AAAA: net.ParseIP("dead:beef::2")},
+				},
 			},
 			"3.app": {
-				&dns.A{A: net.IPv4(10, 42, 0, 3).To4()},
-				&dns.AAAA{AAAA: net.ParseIP("dead:beef::3")},
+				dns.TypeA: {
+					&dns.A{A: net.IPv4(10, 42, 0, 3).To4()},
+				},
+				dns.TypeAAAA: {
+					&dns.AAAA{AAAA: net.ParseIP("dead:beef::3")},
+				},
 			},
 			"app": {
-				&dns.A{A: net.IPv4(10, 42, 0, 1).To4()},
-				&dns.A{A: net.IPv4(10, 42, 0, 2).To4()},
-				&dns.A{A: net.IPv4(10, 42, 0, 3).To4()},
-				&dns.AAAA{AAAA: net.ParseIP("dead:beef::1")},
-				&dns.AAAA{AAAA: net.ParseIP("dead:beef::2")},
-				&dns.AAAA{AAAA: net.ParseIP("dead:beef::3")},
+				dns.TypeA: {
+					&dns.A{A: net.IPv4(10, 42, 0, 1).To4()},
+					&dns.A{A: net.IPv4(10, 42, 0, 2).To4()},
+					&dns.A{A: net.IPv4(10, 42, 0, 3).To4()},
+				},
+				dns.TypeAAAA: {
+					&dns.AAAA{AAAA: net.ParseIP("dead:beef::1")},
+					&dns.AAAA{AAAA: net.ParseIP("dead:beef::2")},
+					&dns.AAAA{AAAA: net.ParseIP("dead:beef::3")},
+				},
 			},
 		},
 	}
@@ -208,9 +224,11 @@ func ExampleServer_recursive() {
 func ExampleServer_recursiveWithZone() {
 	customTLD := &dns.Zone{
 		Origin: "tld.",
-		RRs: map[string][]dns.Record{
+		RRs: dns.RRSet{
 			"foo": {
-				&dns.A{A: net.IPv4(127, 0, 0, 1).To4()},
+				dns.TypeA: {
+					&dns.A{A: net.IPv4(127, 0, 0, 1).To4()},
+				},
 			},
 		},
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -156,6 +156,8 @@ func ExampleServer_recursive() {
 		Forwarder: &dns.Client{
 			Transport: &dns.Transport{
 				Proxy: dns.NameServers{
+					&net.TCPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+					&net.TCPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
 					&net.UDPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
 					&net.UDPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
 				}.RoundRobin(),
@@ -222,7 +224,9 @@ func ExampleServer_recursiveWithZone() {
 		Forwarder: &dns.Client{
 			Transport: &dns.Transport{
 				Proxy: dns.NameServers{
-					&net.UDPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+					&net.TCPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+					&net.TCPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+					&net.UDPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
 					&net.UDPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
 				}.RoundRobin(),
 			},

--- a/handler_test.go
+++ b/handler_test.go
@@ -14,25 +14,29 @@ func TestResolveMux(t *testing.T) {
 	mailZone := &Zone{
 		Origin: "mx.",
 		TTL:    24 * time.Hour,
-		RRs: map[string][]Record{
+		RRs: RRSet{
 			"foo": {
-				&MX{
-					Pref: 101,
-					MX:   "a.foo.mx.",
-				},
-				&MX{
-					Pref: 101,
-					MX:   "b.foo.mx.",
+				TypeMX: {
+					&MX{
+						Pref: 101,
+						MX:   "a.foo.mx.",
+					},
+					&MX{
+						Pref: 101,
+						MX:   "b.foo.mx.",
+					},
 				},
 			},
 			"bar": {
-				&MX{
-					Pref: 101,
-					MX:   "a.bar.mx.",
-				},
-				&MX{
-					Pref: 101,
-					MX:   "b.bar.mx.",
+				TypeMX: {
+					&MX{
+						Pref: 101,
+						MX:   "a.bar.mx.",
+					},
+					&MX{
+						Pref: 101,
+						MX:   "b.bar.mx.",
+					},
 				},
 			},
 		},
@@ -68,10 +72,10 @@ func TestResolveMux(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := len(mailZone.RRs["foo"]), len(msg.Answers); want != got {
+		if want, got := len(mailZone.RRs["foo"][TypeMX]), len(msg.Answers); want != got {
 			t.Fatalf("want %d answers, got %d", want, got)
 		}
-		for i, rec := range mailZone.RRs["foo"] {
+		for i, rec := range mailZone.RRs["foo"][TypeMX] {
 			if want, got := rec, msg.Answers[i].Record; !reflect.DeepEqual(want, got) {
 				t.Errorf("want MX record %#v, got %#v", want, got)
 			}
@@ -95,11 +99,12 @@ func TestResolveMux(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := len(mailZone.RRs["foo"])+len(mailZone.RRs["bar"]), len(msg.Answers); want != got {
+
+		if want, got := len(mailZone.RRs["foo"][TypeMX])+len(mailZone.RRs["bar"][TypeMX]), len(msg.Answers); want != got {
 			t.Fatalf("want %d answers, got %d", want, got)
 		}
 
-		for i, rec := range append(mailZone.RRs["foo"], mailZone.RRs["bar"]...) {
+		for i, rec := range append(mailZone.RRs["foo"][TypeMX], mailZone.RRs["bar"][TypeMX]...) {
 			if want, got := rec, msg.Answers[i].Record; !reflect.DeepEqual(want, got) {
 				t.Errorf("want MX record %#v, got %#v", want, got)
 			}
@@ -123,11 +128,13 @@ func TestResolveMux(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := len(localhostZone.RRs["app"]), len(msg.Answers); want != got {
+
+		answers := append(localhostZone.RRs["app"][TypeA], localhostZone.RRs["app"][TypeAAAA]...)
+		if want, got := len(answers), len(msg.Answers); want != got {
 			t.Fatalf("want %d answers, got %d", want, got)
 		}
 
-		for i, rec := range localhostZone.RRs["app"] {
+		for i, rec := range answers {
 			if want, got := rec, msg.Answers[i].Record; !reflect.DeepEqual(want, got) {
 				t.Errorf("want localhost record %#v, got %#v", want, got)
 			}

--- a/internal/must/cert.go
+++ b/internal/must/cert.go
@@ -56,7 +56,7 @@ func LeafCert(hostname string, parent *Cert) *Cert {
 }
 
 func newCert(hostname string) *Cert {
-	privateKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		panic(err)
 	}

--- a/message.go
+++ b/message.go
@@ -44,6 +44,7 @@ const (
 	TypeTXT   Type = 16  // [RFC1035] text strings
 	TypeAAAA  Type = 28  // [RFC3596] IP6 Address
 	TypeSRV   Type = 33  // [RFC2782] Server Selection
+	TypeDNAME Type = 39  // [RFC6672] DNAME
 	TypeOPT   Type = 41  // [RFC6891][RFC3225] OPT
 	TypeAXFR  Type = 252 // [RFC1035][RFC5936] transfer of an entire zone
 	TypeALL   Type = 255 // [RFC1035][RFC6895] A request for all records the server/cache has available
@@ -78,6 +79,7 @@ var NewRecordByType = map[Type]func() Record{
 	TypeTXT:   func() Record { return new(TXT) },
 	TypeAAAA:  func() Record { return new(AAAA) },
 	TypeSRV:   func() Record { return new(SRV) },
+	TypeDNAME: func() Record { return new(DNAME) },
 	TypeOPT:   func() Record { return new(OPT) },
 }
 
@@ -836,6 +838,31 @@ func (s *SRV) Unpack(b []byte, _ Decompressor) ([]byte, error) {
 
 	var err error
 	s.Target, b, err = decompressor(nil).Unpack(b[6:])
+	return b, err
+}
+
+// DNAME is a DNS DNAME record.
+type DNAME struct {
+	DNAME string
+}
+
+// Type returns the RR type identifier.
+func (DNAME) Type() Type { return TypeDNAME }
+
+// Length returns the encoded RDATA size.
+func (d DNAME) Length(com Compressor) (int, error) {
+	return com.Length(d.DNAME)
+}
+
+// Pack encodes c as RDATA.
+func (d DNAME) Pack(b []byte, com Compressor) ([]byte, error) {
+	return com.Pack(b, d.DNAME)
+}
+
+// Unpack decodes c from RDATA in b.
+func (d *DNAME) Unpack(b []byte, dec Decompressor) ([]byte, error) {
+	var err error
+	d.DNAME, b, err = dec.Unpack(b)
 	return b, err
 }
 

--- a/message.go
+++ b/message.go
@@ -403,7 +403,7 @@ func (r *Resource) Unpack(b []byte, dec Decompressor) ([]byte, error) {
 		return nil, err
 	}
 
-	if len(b) < 4 {
+	if len(b) < 10 {
 		return nil, errResourceLen
 	}
 

--- a/message_test.go
+++ b/message_test.go
@@ -603,6 +603,74 @@ func TestMessagePackUnpack(t *testing.T) {
 			},
 		},
 		{
+			name: ". 60 IN DNAME",
+
+			msg: Message{
+				ID:       0x108,
+				Response: true,
+				Questions: []Question{
+					{
+						Name:  "dname.",
+						Type:  TypeA,
+						Class: ClassIN,
+					},
+				},
+				Answers: []Resource{
+					{
+						Name:  ".",
+						Class: ClassIN,
+						TTL:   60 * time.Second,
+						Record: &DNAME{
+							DNAME: "example.com.",
+						},
+					},
+					{
+						Name:  "dname.example.com.",
+						Class: ClassIN,
+						TTL:   60 * time.Second,
+						Record: &A{
+							A: net.IPv4(127, 0, 0, 1).To4(),
+						},
+					},
+				},
+			},
+
+			raw: []byte{
+				0x01, 0x08, // ID=0x0108
+				0x80, 0x00, // RD=1
+				0x00, 0x01, // QDCOUNT=1
+				0x00, 0x02, // ANCOUNT=2
+				0x00, 0x00, // NSCOUNT=0
+				0x00, 0x00, // ARCOUNT=0
+
+				// dname.	IN	A
+				0x05, 'd', 'n', 'a', 'm', 'e',
+				0x00,
+				0x00, 0x01, 0x00, 0x01, // TYPE=A,CLASS=IN
+
+				// example.com.	IN	DNAME
+				0x00,
+				0x00, 0x27, 0x00, 0x01, // TYPE=DNAME,CLASS=IN
+				0x00, 0x00, 0x00, 0x3C, // TTL=60
+				0x00, 0x0D,
+
+				0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+				0x03, 'c', 'o', 'm',
+				0x00,
+
+				// dname.example.com.	IN	A
+				0x05, 'd', 'n', 'a', 'm', 'e',
+				0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+				0x03, 'c', 'o', 'm',
+				0x00,
+				0x00, 0x01, 0x00, 0x01, // TYPE=A,CLASS=IN
+				0x00, 0x00, 0x00, 0x3C, // TTL=60
+				0x00, 0x04,
+
+				0x7F, 0x00, 0x00, 0x01, // 127.0.0.1
+			},
+		},
+		{
 			name: "compressed response",
 
 			msg: Message{

--- a/message_test.go
+++ b/message_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/benburkert/dns/edns"
 )
 
 func TestQuestionPackUnpack(t *testing.T) {
@@ -647,6 +649,55 @@ func TestMessagePackUnpack(t *testing.T) {
 				0x00, 0x04, // RDLENGTH=5
 
 				0x7F, 0x00, 0x00, 0x01, // 127.0.0.1
+			},
+		},
+		{
+			name: ".	IN	AAAA + OPT",
+
+			msg: Message{
+				ID:               0x1001,
+				RecursionDesired: true,
+				Questions: []Question{
+					{
+						Name:  ".",
+						Type:  TypeAAAA,
+						Class: ClassIN,
+					},
+				},
+				Additionals: []Resource{
+					{
+						Name:  ".",
+						Class: 1280,
+						TTL:   0,
+						Record: &OPT{
+							Options: []edns.Option{
+								edns.Option{
+									Code: edns.OptionCodeCookie,
+									Data: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			raw: []byte{
+				0x10, 0x01, // ID=0x1001
+				0x01, 0x00, // RD=1
+				0x00, 0x01, // QDCOUNT=1
+				0x00, 0x00, // ANCOUNT=0
+				0x00, 0x00, // NSCOUNT=0
+				0x00, 0x01, // ARCOUNT=1
+
+				0x00, 0x00, 0x1C, 0x00, 0x01, // .	IN	AAAA
+				0x00, 0x00, 0x29, // . OPT ...
+				0x05, 0x00, // CLASS=1280 (UDP MTU)
+				0x00, 0x00, 0x00, 0x00, // ex-rcode+flags
+				0x00, 0x0C, // RDLENGTH=12
+
+				0x00, 0x0A, // OPTION-CODE = 10
+				0x00, 0x08, // OPTION-LENGTH = 8
+				0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // Client Cookie (fixed size, 8 bytes)
 			},
 		},
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -671,6 +672,53 @@ func TestMessagePackUnpack(t *testing.T) {
 			},
 		},
 		{
+			name: ". 60 IN CAA",
+
+			msg: Message{
+				ID:       0x109,
+				Response: true,
+				Questions: []Question{
+					{
+						Name:  ".",
+						Type:  TypeCAA,
+						Class: ClassIN,
+					},
+				},
+				Answers: []Resource{
+					{
+						Name:  ".",
+						Class: ClassIN,
+						TTL:   60 * time.Second,
+						Record: &CAA{
+							Tag:   "issue",
+							Value: "pki.example.com",
+						},
+					},
+				},
+			},
+
+			raw: []byte{
+				0x01, 0x09, // ID=0x0109
+				0x80, 0x00, // RD=1
+				0x00, 0x01, // QDCOUNT=1
+				0x00, 0x01, // ANCOUNT=1
+				0x00, 0x00, // NSCOUNT=0
+				0x00, 0x00, // ARCOUNT=0
+
+				0x00, 0x01, 0x01, 0x00, 0x01, // .      IN      CAA
+
+				// .    60      IN      issue "pki.example.com"
+				0x00,
+				0x01, 0x01, 0x00, 0x01, // TYPE=CAA,CLASS=IN
+				0x00, 0x00, 0x00, 0x3C, // TTL=60
+				0x00, 0x16,
+
+				0x00, 0x05,
+				'i', 's', 's', 'u', 'e',
+				'p', 'k', 'i', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+			},
+		},
+		{
 			name: "compressed response",
 
 			msg: Message{
@@ -1178,5 +1226,116 @@ func largeTestMsg() Message {
 				},
 			},
 		},
+	}
+}
+
+func TestInvalidCAA(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+
+		msg Message
+		raw []byte
+
+		err error
+	}{
+		{
+			name: "zero length tag",
+
+			msg: Message{
+				ID:       0x01,
+				Response: true,
+				Questions: []Question{
+					{
+						Name:  ".",
+						Type:  TypeCAA,
+						Class: ClassIN,
+					},
+				},
+				Answers: []Resource{
+					{
+						Name:  ".",
+						Class: ClassIN,
+						TTL:   60 * time.Second,
+						Record: &CAA{
+							IssuerCritical: true,
+							Tag:            "",
+							Value:          "ca.example.com",
+						},
+					},
+				},
+			},
+			raw: []byte{
+				0x00, 0x01, // ID=0x0001
+				0x80, 0x00, // RD=1
+				0x00, 0x01, // QDCOUNT=1
+				0x00, 0x01, // ANCOUNT=1
+				0x00, 0x00, // NSCOUNT=0
+				0x00, 0x00, // ARCOUNT=0
+
+				0x00, 0x01, 0x01, 0x00, 0x01, // .      IN      CAA
+
+				// .    60      IN      '' "ca.example.com"
+				0x00,
+				0x01, 0x01, 0x00, 0x01, // TYPE=CAA,CLASS=IN
+				0x00, 0x00, 0x00, 0x3C, // TTL=60
+				0x00, 0x10,
+
+				0x01, 0x00,
+				'c', 'a', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+			},
+
+			err: errZeroSegLen,
+		},
+		{
+			name: "tag too long",
+
+			msg: Message{
+				ID:       0x01,
+				Response: true,
+				Questions: []Question{
+					{
+						Name:  ".",
+						Type:  TypeCAA,
+						Class: ClassIN,
+					},
+				},
+				Answers: []Resource{
+					{
+						Name:  ".",
+						Class: ClassIN,
+						TTL:   60 * time.Second,
+						Record: &CAA{
+							IssuerCritical: true,
+							Tag:            strings.Repeat("a", 256),
+							Value:          "ca.example.com",
+						},
+					},
+				},
+			},
+
+			err: errSegTooLong,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(string(test.name), func(t *testing.T) {
+			t.Parallel()
+
+			_, err := test.msg.Pack(nil, true)
+			if want, got := test.err, err; want != got {
+				t.Errorf("want pack error %q, got %q", want, got)
+			}
+
+			if len(test.raw) > 0 {
+				_, err = new(Message).Unpack(test.raw)
+				if want, got := test.err, err; want != got {
+					t.Errorf("want unpack error %q, got %q", want, got)
+				}
+			}
+		})
 	}
 }

--- a/nameservers.go
+++ b/nameservers.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"context"
 	cryptorand "crypto/rand"
+	"errors"
 	"io"
 	"math/big"
 	"net"
@@ -14,21 +15,64 @@ type NameServers []net.Addr
 
 // Random picks a random Addr from s every time.
 func (s NameServers) Random(rand io.Reader) ProxyFunc {
-	max := big.NewInt(int64(len(s)))
-	return func(_ context.Context, _ net.Addr) (net.Addr, error) {
+	addrsByNet := s.netAddrsMap()
+
+	maxByNet := make(map[string]*big.Int, len(addrsByNet))
+	for network, addrs := range addrsByNet {
+		maxByNet[network] = big.NewInt(int64(len(addrs)))
+	}
+
+	return func(_ context.Context, addr net.Addr) (net.Addr, error) {
+		network := addr.Network()
+		max, ok := maxByNet[network]
+		if !ok {
+			return nil, errors.New("no nameservers for network: " + network)
+		}
+
+		addrs, ok := addrsByNet[network]
+		if !ok {
+			panic("impossible")
+		}
+
 		idx, err := cryptorand.Int(rand, max)
 		if err != nil {
 			return nil, err
 		}
 
-		return s[idx.Uint64()], nil
+		return addrs[idx.Uint64()], nil
 	}
 }
 
 // RoundRobin picks the next Addr of s by index of the last pick.
 func (s NameServers) RoundRobin() ProxyFunc {
-	var idx uint32
-	return func(_ context.Context, _ net.Addr) (net.Addr, error) {
-		return s[int(atomic.AddUint32(&idx, 1)-1)%len(s)], nil
+	addrsByNet := s.netAddrsMap()
+
+	idxByNet := make(map[string]*uint32, len(s))
+	for network := range addrsByNet {
+		idxByNet[network] = new(uint32)
 	}
+
+	return func(_ context.Context, addr net.Addr) (net.Addr, error) {
+		network := addr.Network()
+		idx, ok := idxByNet[network]
+		if !ok {
+			return nil, errors.New("no nameservers for network: " + network)
+		}
+
+		addrs, ok := addrsByNet[network]
+		if !ok {
+			panic("impossible")
+		}
+
+		return addrs[int(atomic.AddUint32(idx, 1)-1)%len(addrs)], nil
+	}
+}
+
+func (s NameServers) netAddrsMap() map[string][]net.Addr {
+	addrsByNet := make(map[string][]net.Addr, len(s))
+	for _, addr := range s {
+		network := addr.Network()
+		addrsByNet[network] = append(addrsByNet[network], addr)
+	}
+	return addrsByNet
 }

--- a/nameservers_test.go
+++ b/nameservers_test.go
@@ -1,0 +1,92 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	mathrand "math/rand"
+	"net"
+	"testing"
+)
+
+var testNameServers = NameServers{
+	&net.UDPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+	&net.UDPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
+	&net.TCPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+	&net.TCPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
+}
+
+func TestNamserverRoundRobin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+
+		proxyfn ProxyFunc
+		addr    net.Addr
+
+		addrs []net.Addr
+		err   error
+	}{
+		{
+			name: "round-robin-udp",
+
+			proxyfn: testNameServers.RoundRobin(),
+			addr:    new(net.UDPAddr),
+
+			addrs: []net.Addr{
+				&net.UDPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+				&net.UDPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
+				&net.UDPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+				&net.UDPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
+			},
+		},
+		{
+			name: "random-tcp",
+
+			proxyfn: testNameServers.Random(mathrand.New(mathrand.NewSource(0))),
+			addr:    new(net.TCPAddr),
+
+			addrs: []net.Addr{
+				&net.TCPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
+				&net.TCPAddr{IP: net.IPv4(8, 8, 8, 8), Port: 53},
+				&net.TCPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
+			},
+		},
+		{
+			name: "unknown-network",
+
+			proxyfn: testNameServers.RoundRobin(),
+			addr:    new(net.IPAddr),
+
+			err:   errors.New("no nameservers for network: ip"),
+			addrs: make([]net.Addr, 1),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			for i, expected := range test.addrs {
+				addr, err := test.proxyfn(context.Background(), test.addr)
+				if test.err != nil {
+					if want, got := test.err.Error(), err.Error(); want != got {
+						t.Fatalf("want error %q, got %q", want, got)
+					}
+					continue
+				}
+
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if want, got := expected.Network(), addr.Network(); want != got {
+					t.Errorf("want %d network %v, got %v", i, want, got)
+				}
+				if want, got := expected.String(), addr.String(); want != got {
+					t.Errorf("want %d address %v, got %v", i, want, got)
+				}
+			}
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -320,7 +320,8 @@ type serverWriter struct {
 
 func (w serverWriter) Recur(ctx context.Context) (*Message, error) {
 	query := &Query{
-		Message: request(w.query.Message),
+		Message:    request(w.query.Message),
+		RemoteAddr: w.query.RemoteAddr,
 	}
 
 	qs := make([]Question, 0, len(w.query.Questions))

--- a/server.go
+++ b/server.go
@@ -268,14 +268,8 @@ func (w packetWriter) Reply(ctx context.Context) error {
 }
 
 func (w packetWriter) truncate(buf []byte) error {
-	msg := new(Message)
-	if _, err := msg.Unpack(buf[:maxPacketLen]); err != nil && err != errResourceLen {
-		return err
-	}
-	msg.Truncated = true
-
 	var err error
-	if buf, err = msg.Pack(buf[:0], true); err != nil {
+	if buf, err = truncate(buf, maxPacketLen); err != nil {
 		return err
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,69 @@
+package dns
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+func TestStreamSession(t *testing.T) {
+	t.Parallel()
+
+	srv := mustServer(localhostZone)
+
+	addr, err := net.ResolveTCPAddr("tcp", srv.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := new(Transport).DialAddr(context.Background(), addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ss := &streamSession{
+		session: session{
+			Conn:    conn,
+			addr:    addr,
+			client:  new(Client),
+			msgerrc: make(chan msgerr),
+		},
+	}
+
+	msg := &Message{
+		Questions: []Question{
+			{
+				Name:  "app.localhost.",
+				Type:  TypeA,
+				Class: ClassIN,
+			},
+		},
+	}
+
+	buf, err := msg.Pack(nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf = append(make([]byte, 2), buf...)
+	nbo.PutUint16(buf[:2], uint16(len(buf)-2))
+
+	if _, err := ss.Write(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	// test 2 byte length prefix read followed by msg read
+
+	if _, err := ss.Read(buf[:2]); err != nil {
+		t.Fatal(err)
+	}
+	mlen := nbo.Uint16(buf[:2])
+
+	buf = make([]byte, mlen)
+	if _, err := ss.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if buf, err = msg.Unpack(buf); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/zone.go
+++ b/zone.go
@@ -39,6 +39,17 @@ func (z *Zone) ServeDNS(ctx context.Context, w MessageWriter, r *Query) {
 		for _, rr := range rrs[q.Type] {
 			w.Answer(q.Name, z.TTL, rr)
 			found = true
+
+			if r.RecursionDesired && rr.Type() == TypeCNAME {
+				name := rr.(*CNAME).CNAME
+				dn := name[:len(name)-len(z.Origin)-1]
+
+				if rrs, ok := z.RRs[dn]; ok {
+					for _, rr := range rrs[q.Type] {
+						w.Answer(name, z.TTL, rr)
+					}
+				}
+			}
 		}
 	}
 

--- a/zone.go
+++ b/zone.go
@@ -28,6 +28,12 @@ func (z *Zone) ServeDNS(ctx context.Context, w MessageWriter, r *Query) {
 		if !strings.HasSuffix(q.Name, z.Origin) {
 			continue
 		}
+		if q.Type == TypeSOA && q.Name == z.Origin {
+			w.Answer(q.Name, z.TTL, z.SOA)
+			found = true
+
+			continue
+		}
 
 		dn := q.Name[:len(q.Name)-len(z.Origin)-1]
 

--- a/zone_test.go
+++ b/zone_test.go
@@ -15,26 +15,42 @@ var localhostZone = &Zone{
 		NS:   "dns.localhost.",
 		MBox: "hostmaster.localhost.",
 	},
-	RRs: map[string][]Record{
+	RRs: RRSet{
 		"1.app": {
-			&A{net.IPv4(10, 42, 0, 1).To4()},
-			&AAAA{net.ParseIP("dead:beef::1")},
+			TypeA: {
+				&A{net.IPv4(10, 42, 0, 1).To4()},
+			},
+			TypeAAAA: {
+				&AAAA{net.ParseIP("dead:beef::1")},
+			},
 		},
 		"2.app": {
-			&A{net.IPv4(10, 42, 0, 2).To4()},
-			&AAAA{net.ParseIP("dead:beef::2")},
+			TypeA: {
+				&A{net.IPv4(10, 42, 0, 2).To4()},
+			},
+			TypeAAAA: {
+				&AAAA{net.ParseIP("dead:beef::2")},
+			},
 		},
 		"3.app": {
-			&A{net.IPv4(10, 42, 0, 3).To4()},
-			&AAAA{net.ParseIP("dead:beef::3")},
+			TypeA: {
+				&A{net.IPv4(10, 42, 0, 3).To4()},
+			},
+			TypeAAAA: {
+				&AAAA{net.ParseIP("dead:beef::3")},
+			},
 		},
 		"app": {
-			&A{net.IPv4(10, 42, 0, 1).To4()},
-			&A{net.IPv4(10, 42, 0, 2).To4()},
-			&A{net.IPv4(10, 42, 0, 3).To4()},
-			&AAAA{net.ParseIP("dead:beef::1")},
-			&AAAA{net.ParseIP("dead:beef::2")},
-			&AAAA{net.ParseIP("dead:beef::3")},
+			TypeA: {
+				&A{net.IPv4(10, 42, 0, 1).To4()},
+				&A{net.IPv4(10, 42, 0, 2).To4()},
+				&A{net.IPv4(10, 42, 0, 3).To4()},
+			},
+			TypeAAAA: {
+				&AAAA{net.ParseIP("dead:beef::1")},
+				&AAAA{net.ParseIP("dead:beef::2")},
+				&AAAA{net.ParseIP("dead:beef::3")},
+			},
 		},
 	},
 }
@@ -74,7 +90,7 @@ func TestZone(t *testing.T) {
 	}
 
 	for i, answer := range res.Answers {
-		rec := localhostZone.RRs["app"][i]
+		rec := localhostZone.RRs["app"][TypeA][i]
 		if want, got := rec.(*A), answer.Record.(*A); !reflect.DeepEqual(*want, *got) {
 			t.Errorf("want answer record %+v, got %+v", *want, *got)
 		}

--- a/zone_test.go
+++ b/zone_test.go
@@ -130,6 +130,35 @@ func TestZone(t *testing.T) {
 		t.Errorf("want SOA record %+v, got %+v", *want, *got)
 	}
 
+	// test SOA query
+
+	q.Message = &Message{
+		Questions: []Question{
+			{
+				Name:  "localhost.",
+				Type:  TypeSOA,
+				Class: ClassIN,
+			},
+		},
+	}
+
+	if res, err = client.Do(context.Background(), q); err != nil {
+		t.Fatal(err)
+	}
+	if want, got := 1, len(res.Answers); want != got {
+		t.Errorf("want %d answers, got %d", want, got)
+	}
+	if want, got := 0, len(res.Authorities); want != got {
+		t.Errorf("want %d authorities, got %d", want, got)
+	}
+
+	if soa, ok = res.Answers[0].Record.(*SOA); !ok {
+		t.Fatalf("non SOA authority record: %+v", res.Authorities[0])
+	}
+	if want, got := localhostZone.SOA, soa; !reflect.DeepEqual(*want, *got) {
+		t.Errorf("want SOA record %+v, got %+v", *want, *got)
+	}
+
 	// test recursive query + cname
 
 	q.Message = &Message{


### PR DESCRIPTION
The old DNS client did not perform recursive DNS lookups so many sites (most notably, Microsoft) could not be connected to because we couldn't resolve their domain names. This update brings us up to date and resolves this.